### PR TITLE
Fix error "Top-level declarations in .d.ts files must start with eith…

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,6 @@
 import {VError} from 'verror';
 
-class GRPCError extends VError {
+export class GRPCError extends VError {
   code: number;
   name: string;
 }


### PR DESCRIPTION
…er a 'declare' or 'export' modifier."

I running it in ts file.
After install this package, it raises error "Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier."
So I add export at the beginning of class GRPCError.